### PR TITLE
Windows: use protobuf instead of bincode for ipc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,25 +168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
-name = "bincode"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
-dependencies = [
- "bincode_derive",
- "serde",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,7 +1325,6 @@ version = "0.2.0-beta.9"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "boringtun",
  "console-subscriber",
  "criterion",
@@ -1353,6 +1333,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty-hex",
+ "prost",
  "prost-build",
  "protoc-bin-vendored",
  "rand",
@@ -2534,12 +2515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "virtue"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
-
-[[package]]
 name = "walkdir"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,13 +2688,13 @@ name = "windows-redirector"
 version = "0.2.0-beta.9"
 dependencies = [
  "anyhow",
- "bincode",
  "env_logger",
  "hex",
  "internet-packet",
  "log",
  "lru_time_cache",
  "mitmproxy",
+ "prost",
  "tokio",
  "windivert",
  "winres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ repository = "https://github.com/mitmproxy/mitmproxy-rs"
 edition = "2021"
 rust-version = "1.65.0"
 
-[workspace.dependencies]
-bincode = "2.0.0-rc.3"
-
 [package]
 name = "mitmproxy"
 license = "MIT"
@@ -43,13 +40,11 @@ x25519-dalek = "=2.0.0-rc.3"
 async-trait = "0.1.68"
 console-subscriber = { version = "0.1.9", optional = true }
 image = "0.24.6"
+prost = "0.11.9"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }
 smoltcp = { git = 'https://github.com/mhils/smoltcp', rev = 'f65351adfa92db5193f368368cb668bac721fe43' }
-
-[target.'cfg(windows)'.dependencies]
-bincode.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.48.0"

--- a/src/packet_sources/ipc.proto
+++ b/src/packet_sources/ipc.proto
@@ -2,14 +2,21 @@ syntax = "proto3";
 
 package mitmproxy.ipc;
 
-message Packet {
-    bytes data = 1;
-    string process_name = 2;
-    int32 pid = 3;
+message FromRedirector {
+  oneof message {
+    PacketWithMeta packet = 1;
+  }
+}
+message PacketWithMeta {
+  bytes data = 1;
+  uint32 pid = 2;
+  optional string process_name = 3;
 }
 
-message InterceptConf {
-  repeated int32 pids = 1;
-  repeated string process_names = 2;
-  bool invert = 3;
+
+message FromProxy {
+  oneof message {
+    bytes packet = 1;
+    string intercept_spec = 2;
+  }
 }

--- a/src/packet_sources/mod.rs
+++ b/src/packet_sources/mod.rs
@@ -8,6 +8,10 @@ use crate::messages::{NetworkCommand, NetworkEvent};
 pub mod windows;
 pub mod wireguard;
 
+pub mod ipc {
+    include!(concat!(env!("OUT_DIR"), "/mitmproxy.ipc.rs"));
+}
+
 #[async_trait]
 pub trait PacketSourceConf {
     type Task: PacketSourceTask + Send + 'static;

--- a/windows-redirector/Cargo.toml
+++ b/windows-redirector/Cargo.toml
@@ -12,13 +12,13 @@ publish.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 mitmproxy = { path = "../" }
-bincode.workspace = true
 tokio = { version = "1.29", features = ["macros", "net", "rt-multi-thread", "sync", "io-util"] }
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 windivert = "0.6.0"
 lru_time_cache = "0.11.11"
 log = "0.4.18"
 env_logger = "0.10.0"
+prost = "0.11.9"
 internet-packet = { git = "https://github.com/mhils/internet-packet.git", features = ["checksums"] }
 
 [target.'cfg(windows)'.dev-dependencies]


### PR DESCRIPTION
This PR makes us adopt protobuf instead of bincode for IPC on Windows. This allows us to use the same IPC serialization format across OSes.