### PR TITLE
build.rs: use system `protoc` if set via `PROTOC`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
 extern crate prost_build;
 
 fn main() {
-    if let Ok(protoc_path) = protoc_bin_vendored::protoc_bin_path() {
-        std::env::set_var("PROTOC", protoc_path);
-    }
+    let protoc_path = match std::env::var("PROTOC") {
+        Ok(path) if !path.is_empty() => std::path::PathBuf::from(path),
+        _ => protoc_bin_vendored::protoc_bin_path().expect("protoc is not available"),
+    };
+    std::env::set_var("PROTOC", protoc_path);
 
     prost_build::compile_protos(
         &["./src/packet_sources/ipc.proto"],


### PR DESCRIPTION
This allows building the package where `protoc` isn't available from `protoc_bin_vendored`, or when the user prefers to use the one from their system.

For context, this patch is used in Homebrew/homebrew-core#138494. At Homebrew, we avoid using pre-built and/or vendored binaries as much as possible. Also, at the time of writing, the `protoc_bin_vendored` crate does not natively support Apple Silicon (arm64), so another use case would be where an Apple Silicon machine does not have Rosetta installed.
