### PR TITLE
Budle identifier from pid

### DIFF
--- a/macos-redirector/MitmproxyAppleTunnel.xcodeproj/xcuserdata/emanuelemicheletti.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/macos-redirector/MitmproxyAppleTunnel.xcodeproj/xcuserdata/emanuelemicheletti.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -14,8 +14,8 @@
             filePath = "MitmproxyAppleTunnel/Controller/AppDelegate.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "30"
-            endingLineNumber = "30"
+            startingLineNumber = "31"
+            endingLineNumber = "31"
             landmarkName = "applicationShouldTerminate(_:)"
             landmarkType = "7">
          </BreakpointContent>

--- a/macos-redirector/MitmproxyAppleTunnel/Controller/AppDelegate.swift
+++ b/macos-redirector/MitmproxyAppleTunnel/Controller/AppDelegate.swift
@@ -8,12 +8,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         let fromRedirectorPipe = CommandLine.arguments[1]
         let fromProxyPipe = CommandLine.arguments[2]
-        self.proxy.setPipePath(fromRedirectorPipe, fromProxyPipe)
-        self.proxy.getRunningApplication()
+        let terminalPid = CommandLine.arguments[3]
+        self.proxy.setPipePath(fromRedirectorPipe, fromProxyPipe, terminalPid)
+        self.proxy.createProcessList()
         Task.init{
             let interceptConf = DispatchQueue(label: "org.mitmproxy.interceptConf", attributes: .concurrent)
             interceptConf.async {
-                self.proxy.interceptConf()
+                self.proxy.interceptSpec()
             }
             await self.proxy.initVPNTunnelProviderManager()
             await self.proxy.startTunnel()

--- a/src/packet_sources/macos.rs
+++ b/src/packet_sources/macos.rs
@@ -85,7 +85,7 @@ impl PacketSourceConf for MacosConf {
             .arg("--args")
             .arg(&ipc_server.from_redirector_path)
             .arg(&ipc_server.from_proxy_path)
-            .arg(format!("{}", std::os::unix::process::parent_id()))
+            .arg(format!("!{}", std::os::unix::process::parent_id()))
             .spawn();
 
         match result {


### PR DESCRIPTION
`mitmdump -mode osproxy:!google,5476,brave` -> filter out both `pid` and `process_name`
`mitmdump -mode osproxy:google,5675,brave` -> intercept only google process_name, 5675 pid and brave process_name
`mitmdump -mode osproxy` -> intercept all (except for terminal that run mitmproxy)

🔴 PROBLEM 🔴
it does not work if `mitmdump` is launched from a terminal emulator (i.e. kitty)