### PR TITLE
turn `mitmproxy_windows.executable_path` into a method

### DIFF
--- a/mitmproxy-rs/src/server.rs
+++ b/mitmproxy-rs/src/server.rs
@@ -275,7 +275,7 @@ pub fn start_os_proxy(
     {
         let executable_path: PathBuf = py
             .import("mitmproxy_windows")?
-            .getattr("executable_path")?
+            .call_method0("executable_path")?
             .extract()?;
         if !executable_path.exists() {
             return Err(anyhow::anyhow!("{} does not exist", executable_path.display()).into());

--- a/mitmproxy-windows/mitmproxy_windows/__init__.py
+++ b/mitmproxy-windows/mitmproxy_windows/__init__.py
@@ -1,24 +1,34 @@
 from pathlib import Path
 
-here = Path(__file__).parent.absolute()
-executable_path = here / "windows-redirector.exe"
 
-# Development path: This should never happen with precompiled wheels.
-if not executable_path.exists() and (here / "editable.marker").exists():
-    import logging
-    import shutil
-    import subprocess
+def executable_path() -> Path:
+    """
+    Return the Path for windows-redirector.exe.
 
-    logger = logging.getLogger(__name__)
-    logger.warning("Development mode: Compiling windows-redirector.exe...")
+    For shipped wheels this is just the file in the package,
+    for development setups this may invoke cargo to build it.
+    """
+    here = Path(__file__).parent.absolute()
+    exe = here / "windows-redirector.exe"
 
-    # Build Redirector
-    subprocess.run(["cargo", "build"], cwd=here.parent / "redirector", check=True)
-    # Copy WinDivert to target/debug/
-    target_debug = here.parent.parent / "target/debug"
-    for f in ["WinDivert.dll", "WinDivert.lib", "WinDivert64.sys"]:
-        if not (target_debug / f).exists():
-            shutil.copy(here / f, target_debug / f)
+    # Development path: This should never happen with precompiled wheels.
+    if not exe.exists() and (here / "editable.marker").exists():
+        import logging
+        import shutil
+        import subprocess
 
-    logger.warning("Development mode: Using target/debug/windows-redirector.exe...")
-    executable_path = target_debug / "windows-redirector.exe"
+        logger = logging.getLogger(__name__)
+        logger.warning("Development mode: Compiling windows-redirector.exe...")
+
+        # Build Redirector
+        subprocess.run(["cargo", "build"], cwd=here.parent / "redirector", check=True)
+        # Copy WinDivert to target/debug/
+        target_debug = here.parent.parent / "target/debug"
+        for f in ["WinDivert.dll", "WinDivert.lib", "WinDivert64.sys"]:
+            if not (target_debug / f).exists():
+                shutil.copy(here / f, target_debug / f)
+
+        logger.warning("Development mode: Using target/debug/windows-redirector.exe...")
+        exe = target_debug / "windows-redirector.exe"
+
+    return exe


### PR DESCRIPTION
now that this is auto-imported to check for missing packages, we don't want dev compiles on every run