### PR TITLE
Intercept spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.5.1
+## 0.6.0
+
+- Change intercept spec syntax.
+
+## 0.5.2
 
 - Dependency updates.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "macos-certificate-truster"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "apple-security-framework",
 ]
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "mitm-wg-test-client"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "boringtun",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mitmproxy"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "apple-security-framework",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "mitmproxy_rs"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "boringtun",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "windows-redirector"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
     "Fabio Valentini <decathorpe@gmail.com>",
     "Maximilian Hils <cargo@maximilianhils.com>",
 ]
-version = "0.5.2"
+version = "0.6.0"
 publish = false
 repository = "https://github.com/mitmproxy/mitmproxy-rs"
 edition = "2021"

--- a/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
+++ b/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
@@ -139,11 +139,7 @@ struct MitmproxyIpc_InterceptConf {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var pids: [UInt32] = []
-
-  var processNames: [String] = []
-
-  var invert: Bool = false
+  var actions: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -510,9 +506,7 @@ extension MitmproxyIpc_Packet: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 extension MitmproxyIpc_InterceptConf: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".InterceptConf"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "pids"),
-    2: .standard(proto: "process_names"),
-    3: .same(proto: "invert"),
+    1: .same(proto: "actions"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -521,31 +515,21 @@ extension MitmproxyIpc_InterceptConf: SwiftProtobuf.Message, SwiftProtobuf._Mess
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedUInt32Field(value: &self.pids) }()
-      case 2: try { try decoder.decodeRepeatedStringField(value: &self.processNames) }()
-      case 3: try { try decoder.decodeSingularBoolField(value: &self.invert) }()
+      case 1: try { try decoder.decodeRepeatedStringField(value: &self.actions) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.pids.isEmpty {
-      try visitor.visitPackedUInt32Field(value: self.pids, fieldNumber: 1)
-    }
-    if !self.processNames.isEmpty {
-      try visitor.visitRepeatedStringField(value: self.processNames, fieldNumber: 2)
-    }
-    if self.invert != false {
-      try visitor.visitSingularBoolField(value: self.invert, fieldNumber: 3)
+    if !self.actions.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.actions, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: MitmproxyIpc_InterceptConf, rhs: MitmproxyIpc_InterceptConf) -> Bool {
-    if lhs.pids != rhs.pids {return false}
-    if lhs.processNames != rhs.processNames {return false}
-    if lhs.invert != rhs.invert {return false}
+    if lhs.actions != rhs.actions {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
+++ b/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
@@ -139,6 +139,8 @@ struct MitmproxyIpc_InterceptConf {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  var `default`: Bool = false
+
   var actions: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -506,7 +508,8 @@ extension MitmproxyIpc_Packet: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
 extension MitmproxyIpc_InterceptConf: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".InterceptConf"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "actions"),
+    1: .same(proto: "default"),
+    2: .same(proto: "actions"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -515,20 +518,25 @@ extension MitmproxyIpc_InterceptConf: SwiftProtobuf.Message, SwiftProtobuf._Mess
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedStringField(value: &self.actions) }()
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.`default`) }()
+      case 2: try { try decoder.decodeRepeatedStringField(value: &self.actions) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.`default` != false {
+      try visitor.visitSingularBoolField(value: self.`default`, fieldNumber: 1)
+    }
     if !self.actions.isEmpty {
-      try visitor.visitRepeatedStringField(value: self.actions, fieldNumber: 1)
+      try visitor.visitRepeatedStringField(value: self.actions, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: MitmproxyIpc_InterceptConf, rhs: MitmproxyIpc_InterceptConf) -> Bool {
+    if lhs.`default` != rhs.`default` {return false}
     if lhs.actions != rhs.actions {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/mitmproxy-macos/redirector/network-extension/TransparentProxyProvider.swift
+++ b/mitmproxy-macos/redirector/network-extension/TransparentProxyProvider.swift
@@ -44,7 +44,7 @@ class TransparentProxyProvider: NETransparentProxyProvider {
             do {
                 while let spec = try await control.receive(ipc: MitmproxyIpc_InterceptConf.self) {
                     log.debug("Received spec: \(String(describing: spec), privacy: .public)")
-                    self.spec = InterceptConf(from: spec)
+                    self.spec = try InterceptConf(from: spec)
                 }
             } catch {
                 log.error("Error on control channel: \(String(describing: error), privacy: .public)")

--- a/mitmproxy-windows/redirector/src/main2.rs
+++ b/mitmproxy-windows/redirector/src/main2.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<()> {
     let tx_clone = event_tx.clone();
     thread::spawn(move || relay_network_events(network_handle, tx_clone));
 
-    let mut state = InterceptConf::new(vec![], vec![], false);
+    let mut state = InterceptConf::disabled();
     event_tx.send(Event::Ipc(ipc::from_proxy::Message::InterceptConf(state.clone().into())))?;
 
     tokio::spawn(async move {
@@ -351,7 +351,7 @@ async fn main() -> Result<()> {
                 inject_handle.send(&packet)?;
             }
             Event::Ipc(ipc::from_proxy::Message::InterceptConf(conf)) => {
-                state = conf.into();
+                state = conf.try_into()?;
                 info!("{}", state.description());
 
                 // Handle preexisting connections.

--- a/src/ipc/mitmproxy_ipc.proto
+++ b/src/ipc/mitmproxy_ipc.proto
@@ -30,7 +30,8 @@ message Packet {
 }
 // Intercept conf (macOS Control Stream)
 message InterceptConf {
-  repeated string actions = 1;
+  bool default = 1;
+  repeated string actions = 2;
 }
 // New flow (macOS TCP/UDP Stream)
 message NewFlow {

--- a/src/ipc/mitmproxy_ipc.proto
+++ b/src/ipc/mitmproxy_ipc.proto
@@ -30,9 +30,7 @@ message Packet {
 }
 // Intercept conf (macOS Control Stream)
 message InterceptConf {
-  repeated uint32 pids = 1;
-  repeated string process_names = 2;
-  bool invert = 3;
+  repeated string actions = 1;
 }
 // New flow (macOS TCP/UDP Stream)
 message NewFlow {

--- a/src/ipc/mitmproxy_ipc.rs
+++ b/src/ipc/mitmproxy_ipc.rs
@@ -51,7 +51,9 @@ pub struct Packet {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InterceptConf {
-    #[prost(string, repeated, tag = "1")]
+    #[prost(bool, tag = "1")]
+    pub default: bool,
+    #[prost(string, repeated, tag = "2")]
     pub actions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// New flow (macOS TCP/UDP Stream)

--- a/src/ipc/mitmproxy_ipc.rs
+++ b/src/ipc/mitmproxy_ipc.rs
@@ -51,12 +51,8 @@ pub struct Packet {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InterceptConf {
-    #[prost(uint32, repeated, tag = "1")]
-    pub pids: ::prost::alloc::vec::Vec<u32>,
-    #[prost(string, repeated, tag = "2")]
-    pub process_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    #[prost(bool, tag = "3")]
-    pub invert: bool,
+    #[prost(string, repeated, tag = "1")]
+    pub actions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// New flow (macOS TCP/UDP Stream)
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -25,6 +25,7 @@ impl From<SocketAddr> for Address {
 impl From<intercept_conf::InterceptConf> for InterceptConf {
     fn from(conf: intercept_conf::InterceptConf) -> Self {
         InterceptConf {
+            default: conf.default(),
             actions: conf.actions(),
         }
     }

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -25,14 +25,15 @@ impl From<SocketAddr> for Address {
 impl From<intercept_conf::InterceptConf> for InterceptConf {
     fn from(conf: intercept_conf::InterceptConf) -> Self {
         InterceptConf {
-            pids: conf.pids.into_iter().collect(),
-            process_names: conf.process_names,
-            invert: conf.invert,
+            actions: conf.actions(),
         }
     }
 }
-impl From<InterceptConf> for intercept_conf::InterceptConf {
-    fn from(conf: InterceptConf) -> Self {
-        intercept_conf::InterceptConf::new(conf.pids, conf.process_names, conf.invert)
+
+impl TryFrom<InterceptConf> for intercept_conf::InterceptConf {
+    type Error = anyhow::Error;
+
+    fn try_from(conf: InterceptConf) -> Result<Self, Self::Error> {
+        intercept_conf::InterceptConf::try_from(conf.actions)
     }
 }


### PR DESCRIPTION
/cc @sudowoodo200 - here's an alternative approach to fix the infinite loop. We slightly change the syntax of intercept specs:

```
curl,!4123  # processes with "curl" but not PID 4123
!4123  # everything but PID 4123
url,!curl  # processes with "url" but without "curl" in their name
4123  # pid 4123 only
```

What do you think?