### PR TITLE
Handle errors when remote host has closed UDP socket

### DIFF
--- a/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
+++ b/mitmproxy-macos/redirector/ipc/mitmproxy_ipc.pb.swift
@@ -21,7 +21,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// Packet with associated tunnel info (Windows pipe to mitmproxy)
-struct MitmproxyIpc_PacketWithMeta {
+struct MitmproxyIpc_PacketWithMeta: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -44,7 +44,7 @@ struct MitmproxyIpc_PacketWithMeta {
   fileprivate var _tunnelInfo: MitmproxyIpc_TunnelInfo? = nil
 }
 
-struct MitmproxyIpc_TunnelInfo {
+struct MitmproxyIpc_TunnelInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -68,7 +68,7 @@ struct MitmproxyIpc_TunnelInfo {
 }
 
 /// Packet or intercept spec (Windows pipe to redirector)
-struct MitmproxyIpc_FromProxy {
+struct MitmproxyIpc_FromProxy: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -93,35 +93,17 @@ struct MitmproxyIpc_FromProxy {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Message: Equatable {
+  enum OneOf_Message: Equatable, Sendable {
     case packet(MitmproxyIpc_Packet)
     case interceptConf(MitmproxyIpc_InterceptConf)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: MitmproxyIpc_FromProxy.OneOf_Message, rhs: MitmproxyIpc_FromProxy.OneOf_Message) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.packet, .packet): return {
-        guard case .packet(let l) = lhs, case .packet(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.interceptConf, .interceptConf): return {
-        guard case .interceptConf(let l) = lhs, case .interceptConf(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
 /// Packet (macOS UDP Stream)
-struct MitmproxyIpc_Packet {
+struct MitmproxyIpc_Packet: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -134,7 +116,7 @@ struct MitmproxyIpc_Packet {
 }
 
 /// Intercept conf (macOS Control Stream)
-struct MitmproxyIpc_InterceptConf {
+struct MitmproxyIpc_InterceptConf: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -149,7 +131,7 @@ struct MitmproxyIpc_InterceptConf {
 }
 
 /// New flow (macOS TCP/UDP Stream)
-struct MitmproxyIpc_NewFlow {
+struct MitmproxyIpc_NewFlow: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -174,34 +156,16 @@ struct MitmproxyIpc_NewFlow {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Message: Equatable {
+  enum OneOf_Message: Equatable, Sendable {
     case tcp(MitmproxyIpc_TcpFlow)
     case udp(MitmproxyIpc_UdpFlow)
 
-  #if !swift(>=4.1)
-    static func ==(lhs: MitmproxyIpc_NewFlow.OneOf_Message, rhs: MitmproxyIpc_NewFlow.OneOf_Message) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.tcp, .tcp): return {
-        guard case .tcp(let l) = lhs, case .tcp(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.udp, .udp): return {
-        guard case .udp(let l) = lhs, case .udp(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   init() {}
 }
 
-struct MitmproxyIpc_TcpFlow {
+struct MitmproxyIpc_TcpFlow: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -232,7 +196,7 @@ struct MitmproxyIpc_TcpFlow {
   fileprivate var _tunnelInfo: MitmproxyIpc_TunnelInfo? = nil
 }
 
-struct MitmproxyIpc_UdpFlow {
+struct MitmproxyIpc_UdpFlow: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -263,7 +227,7 @@ struct MitmproxyIpc_UdpFlow {
   fileprivate var _tunnelInfo: MitmproxyIpc_TunnelInfo? = nil
 }
 
-struct MitmproxyIpc_UdpPacket {
+struct MitmproxyIpc_UdpPacket: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -286,7 +250,7 @@ struct MitmproxyIpc_UdpPacket {
   fileprivate var _remoteAddress: MitmproxyIpc_Address? = nil
 }
 
-struct MitmproxyIpc_Address {
+struct MitmproxyIpc_Address: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -299,21 +263,6 @@ struct MitmproxyIpc_Address {
 
   init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension MitmproxyIpc_PacketWithMeta: @unchecked Sendable {}
-extension MitmproxyIpc_TunnelInfo: @unchecked Sendable {}
-extension MitmproxyIpc_FromProxy: @unchecked Sendable {}
-extension MitmproxyIpc_FromProxy.OneOf_Message: @unchecked Sendable {}
-extension MitmproxyIpc_Packet: @unchecked Sendable {}
-extension MitmproxyIpc_InterceptConf: @unchecked Sendable {}
-extension MitmproxyIpc_NewFlow: @unchecked Sendable {}
-extension MitmproxyIpc_NewFlow.OneOf_Message: @unchecked Sendable {}
-extension MitmproxyIpc_TcpFlow: @unchecked Sendable {}
-extension MitmproxyIpc_UdpFlow: @unchecked Sendable {}
-extension MitmproxyIpc_UdpPacket: @unchecked Sendable {}
-extension MitmproxyIpc_Address: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/mitmproxy-rs/src/udp_client.rs
+++ b/mitmproxy-rs/src/udp_client.rs
@@ -9,7 +9,6 @@ use tokio::sync::oneshot;
 
 use crate::stream::{Stream, StreamState};
 use mitmproxy::messages::{ConnectionId, TransportCommand, TunnelInfo};
-use mitmproxy::packet_sources::udp::remote_host_closed_conn;
 use mitmproxy::MAX_PACKET_SIZE;
 
 /// Start a UDP client that is configured with the given parameters:

--- a/mitmproxy-rs/src/udp_client.rs
+++ b/mitmproxy-rs/src/udp_client.rs
@@ -114,6 +114,7 @@ impl UdpClientTask {
             tokio::select! {
                 // wait for transport_events_tx channel capacity...
                 len = self.socket.recv(&mut udp_buf), if packet_tx.is_some() => {
+                    #[cfg(windows)]
                     if let Err(e) = &len {
                         if remote_host_closed_conn(e) {
                             continue;

--- a/mitmproxy-rs/src/udp_client.rs
+++ b/mitmproxy-rs/src/udp_client.rs
@@ -9,8 +9,8 @@ use tokio::sync::oneshot;
 
 use crate::stream::{Stream, StreamState};
 use mitmproxy::messages::{ConnectionId, TransportCommand, TunnelInfo};
-use mitmproxy::MAX_PACKET_SIZE;
 use mitmproxy::packet_sources::udp::remote_host_closed_conn;
+use mitmproxy::MAX_PACKET_SIZE;
 
 /// Start a UDP client that is configured with the given parameters:
 ///

--- a/mitmproxy-rs/src/udp_client.rs
+++ b/mitmproxy-rs/src/udp_client.rs
@@ -11,6 +11,8 @@ use crate::stream::{Stream, StreamState};
 use mitmproxy::messages::{ConnectionId, TransportCommand, TunnelInfo};
 use mitmproxy::MAX_PACKET_SIZE;
 
+use mitmproxy::packet_sources::udp::remote_host_closed_conn;
+
 /// Start a UDP client that is configured with the given parameters:
 ///
 /// - `host`: The host address.
@@ -112,14 +114,11 @@ impl UdpClientTask {
         loop {
             tokio::select! {
                 // wait for transport_events_tx channel capacity...
-                len = self.socket.recv(&mut udp_buf), if packet_tx.is_some() => {
-                    #[cfg(windows)]
-                    if let Err(e) = &len {
-                        if remote_host_closed_conn(e) {
-                            continue;
-                        }
+                r = self.socket.recv(&mut udp_buf), if packet_tx.is_some() => {
+                    if remote_host_closed_conn(&r) {
+                        continue;
                     }
-                    let len = len.context("UDP recv() failed")?;
+                    let len = r.context("UDP recv() failed")?;
                     packet_tx
                         .take()
                         .unwrap()

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -1,4 +1,5 @@
 use std::net::{Ipv4Addr, SocketAddr};
+use std::io::Error;
 
 use anyhow::{Context, Result};
 
@@ -12,6 +13,20 @@ use crate::messages::{TransportCommand, TransportEvent, TunnelInfo};
 use crate::network::udp::{UdpHandler, UdpPacket};
 use crate::network::MAX_PACKET_SIZE;
 use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
+
+const REMOTE_HOST_CLOSED_CONN_ERR: i32 = 10054;
+
+pub fn remote_host_closed_conn(e: &Error) -> bool {
+    #[cfg(windows)]
+    {
+        if matches!(e.raw_os_error(), Some(REMOTE_HOST_CLOSED_CONN_ERR)) {
+            // Workaround for https://stackoverflow.com/a/73792103:
+            // We get random errors here on Windows if a previous send() failed.
+            return true
+        }
+    }
+    false
+}
 
 pub struct UdpConf {
     pub host: String,
@@ -88,11 +103,8 @@ impl PacketSourceTask for UdpTask {
                 },
                 // ... or process incoming packets
                 r = self.socket.recv_from(&mut udp_buf), if py_tx_available => {
-                    #[cfg(windows)]
                     if let Err(e) = &r {
-                        if matches!(e.raw_os_error(), Some(10054)) {
-                            // Workaround for https://stackoverflow.com/a/73792103:
-                            // We get random errors here on Windows if a previous send() failed.
+                        if remote_host_closed_conn(e) {
                             continue;
                         }
                     }

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -19,7 +19,7 @@ pub fn remote_host_closed_conn<T>(_res: &Result<T, std::io::Error>) -> bool {
         // Workaround for https://stackoverflow.com/a/73792103:
         // We get random errors here on Windows if a previous send() failed.
         const REMOTE_HOST_CLOSED_CONN_ERR: i32 = 10054;
-        return matches!(e.raw_os_error(), Some(REMOTE_HOST_CLOSED_CONN_ERR))
+        return matches!(e.raw_os_error(), Some(REMOTE_HOST_CLOSED_CONN_ERR));
     }
     false
 }

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -1,5 +1,5 @@
-use std::net::{Ipv4Addr, SocketAddr};
 use std::io::Error;
+use std::net::{Ipv4Addr, SocketAddr};
 
 use anyhow::{Context, Result};
 
@@ -22,7 +22,7 @@ pub fn remote_host_closed_conn(e: &Error) -> bool {
         if matches!(e.raw_os_error(), Some(REMOTE_HOST_CLOSED_CONN_ERR)) {
             // Workaround for https://stackoverflow.com/a/73792103:
             // We get random errors here on Windows if a previous send() failed.
-            return true
+            return true;
         }
     }
     false

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -21,7 +21,7 @@ pub fn remote_host_closed_conn(e: &Error) -> bool {
         // We get random errors here on Windows if a previous send() failed.
         return true;
     }
-    return false;
+    false
 }
 
 pub struct UdpConf {

--- a/src/packet_sources/wireguard.rs
+++ b/src/packet_sources/wireguard.rs
@@ -23,7 +23,6 @@ use crate::messages::{
     NetworkCommand, NetworkEvent, SmolPacket, TransportCommand, TransportEvent, TunnelInfo,
 };
 use crate::network::{add_network_layer, MAX_PACKET_SIZE};
-use crate::packet_sources::udp::remote_host_closed_conn;
 use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
 
 // WireGuard headers are 60 bytes for IPv4 and 80 bytes for IPv6

--- a/src/packet_sources/wireguard.rs
+++ b/src/packet_sources/wireguard.rs
@@ -23,8 +23,8 @@ use crate::messages::{
     NetworkCommand, NetworkEvent, SmolPacket, TransportCommand, TransportEvent, TunnelInfo,
 };
 use crate::network::{add_network_layer, MAX_PACKET_SIZE};
-use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
 use crate::packet_sources::udp::remote_host_closed_conn;
+use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
 
 // WireGuard headers are 60 bytes for IPv4 and 80 bytes for IPv6
 const WG_HEADER_SIZE: usize = 80;

--- a/src/packet_sources/wireguard.rs
+++ b/src/packet_sources/wireguard.rs
@@ -157,6 +157,7 @@ impl PacketSourceTask for WireGuardTask {
                 exit = &mut self.network_task_handle => break exit.context("network task panic")?.context("network task error")?,
                 // wait for WireGuard packets incoming on the UDP socket
                 r = self.socket.recv_from(&mut udp_buf) => {
+                    #[cfg(windows)]
                     if let Err(e) = &r {
                         if remote_host_closed_conn(e) {
                             continue;

--- a/src/packet_sources/wireguard.rs
+++ b/src/packet_sources/wireguard.rs
@@ -24,6 +24,7 @@ use crate::messages::{
 };
 use crate::network::{add_network_layer, MAX_PACKET_SIZE};
 use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
+use crate::packet_sources::udp::remote_host_closed_conn;
 
 // WireGuard headers are 60 bytes for IPv4 and 80 bytes for IPv6
 const WG_HEADER_SIZE: usize = 80;
@@ -156,11 +157,8 @@ impl PacketSourceTask for WireGuardTask {
                 exit = &mut self.network_task_handle => break exit.context("network task panic")?.context("network task error")?,
                 // wait for WireGuard packets incoming on the UDP socket
                 r = self.socket.recv_from(&mut udp_buf) => {
-                    #[cfg(windows)]
                     if let Err(e) = &r {
-                        if matches!(e.raw_os_error(), Some(10054)) {
-                            // Workaround for https://stackoverflow.com/a/73792103:
-                            // We get random errors here on Windows if a previous send() failed.
+                        if remote_host_closed_conn(e) {
                             continue;
                         }
                     }


### PR DESCRIPTION
An error is caused(not raised) whenever we try to send data to a remote host that has closed the socket through UDP. This error is raised later only when we try to receive data through this socket. This PR handles such errors by ignoring(silencing) them 