### PR TITLE
Set IPV6_V6ONLY flag for UDP sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower",
  "tower-service",
@@ -1398,7 +1398,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1644,6 +1644,7 @@ dependencies = [
  "rand_core",
  "security-framework",
  "smoltcp",
+ "socket2 0.4.10",
  "sysinfo",
  "tokio",
  "tokio-util",
@@ -2384,6 +2385,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -2572,7 +2583,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -2643,7 +2654,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -1398,7 +1398,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1644,7 +1644,7 @@ dependencies = [
  "rand_core",
  "security-framework",
  "smoltcp",
- "socket2 0.4.10",
+ "socket2",
  "sysinfo",
  "tokio",
  "tokio-util",
@@ -2385,16 +2385,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
@@ -2583,7 +2573,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -2654,7 +2644,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ lru_time_cache = "0.11.11"
 internet-packet = { version = "0.2.0", features = ["smoltcp"] }
 data-encoding = "2.4.0"
 hickory-resolver = "0.24.1"
+socket2 = "0.4"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ lru_time_cache = "0.11.11"
 internet-packet = { version = "0.2.0", features = ["smoltcp"] }
 data-encoding = "2.4.0"
 hickory-resolver = "0.24.1"
-socket2 = "0.4"
+socket2 = "0.5.7"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -3,12 +3,12 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 
+use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::mpsc::{Permit, UnboundedReceiver};
 use tokio::{
     net::UdpSocket,
     sync::{broadcast, mpsc::Sender},
 };
-use socket2::{Socket, Domain, Type, Protocol};
 
 use crate::messages::{TransportCommand, TransportEvent, TunnelInfo};
 use crate::network::udp::{UdpHandler, UdpPacket};
@@ -25,7 +25,6 @@ pub fn remote_host_closed_conn<T>(_res: &Result<T, std::io::Error>) -> bool {
     }
     false
 }
-
 
 pub struct UdpConf {
     pub host: String,
@@ -58,10 +57,14 @@ impl PacketSourceConf for UdpConf {
 
         // Ensure that IPv6 sockets listen on IPv6 only
         if local_addr.is_ipv6() {
-            sock2.set_only_v6(true).context("Failed to set IPV6_V6ONLY flag")?;
+            sock2
+                .set_only_v6(true)
+                .context("Failed to set IPV6_V6ONLY flag")?;
         }
 
-        sock2.bind(&local_addr.into()).context(format!("Failed to bind UDP socket to {}", addr))?;
+        sock2
+            .bind(&local_addr.into())
+            .context(format!("Failed to bind UDP socket to {}", addr))?;
         let socket = UdpSocket::from_std(sock2.into())?;
 
         log::debug!("UDP server listening on {} ...", local_addr);


### PR DESCRIPTION
If this flag is unset, listening on v6 listens on v6 as well as v4 due to which we can not start a v6 server if we're already listening at the same address on v4