### PR TITLE
macos: improve redirector error messages

### DIFF
--- a/src/certificates/macos.rs
+++ b/src/certificates/macos.rs
@@ -11,8 +11,8 @@ use tokio::process::Command;
 pub fn add_cert(der: Vec<u8>, path: &str) -> Result<()> {
     let cert = SecCertificate::from_der(&der)?;
     let add_ref = AddRef::Certificate(cert);
-    let add_option = ItemAddOptions::new(ItemAddValue::Ref(add_ref))
-        .set_label("mitmproxy");
+    let mut  add_option = ItemAddOptions::new(ItemAddValue::Ref(add_ref));
+    add_option.set_label("mitmproxy");
 
     let search_result = ItemSearchOptions::new()
         .class(ItemClass::certificate())

--- a/src/certificates/macos.rs
+++ b/src/certificates/macos.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use security_framework::{
     certificate::SecCertificate,
     item::{
-        add_item, AddRef, ItemAddOptions, ItemAddValue, ItemClass, ItemSearchOptions, Reference,
+        AddRef, ItemAddOptions, ItemAddValue, ItemClass, ItemSearchOptions, Reference,
         SearchResult,
     },
 };
@@ -12,8 +12,7 @@ pub fn add_cert(der: Vec<u8>, path: &str) -> Result<()> {
     let cert = SecCertificate::from_der(&der)?;
     let add_ref = AddRef::Certificate(cert);
     let add_option = ItemAddOptions::new(ItemAddValue::Ref(add_ref))
-        .set_label("mitmproxy")
-        .to_dictionary();
+        .set_label("mitmproxy");
 
     let search_result = ItemSearchOptions::new()
         .class(ItemClass::certificate())
@@ -26,7 +25,7 @@ pub fn add_cert(der: Vec<u8>, path: &str) -> Result<()> {
         cert.delete()?;
     }
 
-    add_item(add_option)?;
+    add_option.add()?;
 
     Command::new("open")
         .arg(path)

--- a/src/certificates/macos.rs
+++ b/src/certificates/macos.rs
@@ -2,8 +2,7 @@ use anyhow::{anyhow, Result};
 use security_framework::{
     certificate::SecCertificate,
     item::{
-        AddRef, ItemAddOptions, ItemAddValue, ItemClass, ItemSearchOptions, Reference,
-        SearchResult,
+        AddRef, ItemAddOptions, ItemAddValue, ItemClass, ItemSearchOptions, Reference, SearchResult,
     },
 };
 use tokio::process::Command;
@@ -11,7 +10,7 @@ use tokio::process::Command;
 pub fn add_cert(der: Vec<u8>, path: &str) -> Result<()> {
     let cert = SecCertificate::from_der(&der)?;
     let add_ref = AddRef::Certificate(cert);
-    let mut  add_option = ItemAddOptions::new(ItemAddValue::Ref(add_ref));
+    let mut add_option = ItemAddOptions::new(ItemAddValue::Ref(add_ref));
     add_option.set_label("mitmproxy");
 
     let search_result = ItemSearchOptions::new()

--- a/src/packet_sources/macos.rs
+++ b/src/packet_sources/macos.rs
@@ -235,7 +235,7 @@ impl ConnectionTask {
                 bail!("no local address")
             };
             SocketAddr::try_from(addr)
-                .with_context(|| format!("invalid local_address: {}", addr))?
+                .with_context(|| format!("invalid local_address: {:?}", addr))?
         };
         let mut remote_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let (command_tx, mut command_rx) = unbounded_channel();
@@ -253,7 +253,7 @@ impl ConnectionTask {
                     ).context("invalid IPC message")?;
                     let dst_addr = {
                         let Some(dst_addr) = &packet.remote_address else { bail!("no remote addr") };
-                        SocketAddr::try_from(dst_addr).with_context(|| format!("invalid remote_address: {}", dst_addr))?
+                        SocketAddr::try_from(dst_addr).with_context(|| format!("invalid remote_address: {:?}", dst_addr))?
                     };
 
                     // We can only send ConnectionEstablished once we know the destination address.

--- a/src/packet_sources/macos.rs
+++ b/src/packet_sources/macos.rs
@@ -200,10 +200,16 @@ impl ConnectionTask {
         match new_flow {
             NewFlow {
                 message: Some(ipc::new_flow::Message::Tcp(tcp_flow)),
-            } => self.handle_tcp(tcp_flow).await.context("failed to handle TCP stream"),
+            } => self
+                .handle_tcp(tcp_flow)
+                .await
+                .context("failed to handle TCP stream"),
             NewFlow {
                 message: Some(ipc::new_flow::Message::Udp(udp_flow)),
-            } => self.handle_udp(udp_flow).await.context("failed to handle UDP stream"),
+            } => self
+                .handle_udp(udp_flow)
+                .await
+                .context("failed to handle UDP stream"),
             _ => bail!("Received invalid IPC message: {:?}", new_flow),
         }
     }
@@ -228,7 +234,8 @@ impl ConnectionTask {
             let Some(addr) = &flow.local_address else {
                 bail!("no local address")
             };
-            SocketAddr::try_from(addr).with_context(|| format!("invalid local_address: {}", addr))?
+            SocketAddr::try_from(addr)
+                .with_context(|| format!("invalid local_address: {}", addr))?
         };
         let mut remote_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let (command_tx, mut command_rx) = unbounded_channel();


### PR DESCRIPTION
I got a weird "Connection task failure: invalid IP address syntax" in my logs, want to find out more.