### PR TITLE
Add `tun` mode on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +145,12 @@ dependencies = [
  "quote",
  "syn 2.0.68",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -285,6 +303,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "boringtun"
 version = "0.6.0"
 source = "git+https://github.com/cloudflare/boringtun?rev=e3252d9c4f4c8fc628995330f45369effd4660a1#e3252d9c4f4c8fc628995330f45369effd4660a1"
@@ -336,6 +367,26 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "c2rust-bitfields"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367e5d1b30f28be590b6b3868da1578361d29d9bfac516d22f497d28ed7c9055"
+dependencies = [
+ "c2rust-bitfields-derive",
+]
+
+[[package]]
+name = "c2rust-bitfields-derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a279db9c50c4024eeca1a763b6e0f033848ce74e83e47454bcf8a8a98f7b0b56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "cast"
@@ -507,6 +558,15 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console-api"
@@ -843,6 +903,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1055,16 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1518,6 +1615,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1803,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tokio-util",
+ "tun2",
  "windows 0.57.0",
  "x25519-dalek",
 ]
@@ -1821,6 +1929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,7 +1954,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1880,6 +1994,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "plotters"
@@ -2823,6 +2948,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tun2"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294ac0e21fef392b8952f1dd538bc5752fd7c2ebfde1c204b0dd09aaa5489cd0"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "futures",
+ "futures-core",
+ "ipnet",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "windows-sys 0.59.0",
+ "wintun-bindings",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,7 +3217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3083,7 +3229,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3131,7 +3277,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3149,7 +3295,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3169,18 +3324,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3191,9 +3346,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3203,9 +3358,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3215,15 +3370,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3233,9 +3388,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3245,9 +3400,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3257,9 +3412,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3269,9 +3424,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"
@@ -3290,6 +3445,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml",
+]
+
+[[package]]
+name = "wintun-bindings"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74675b7fccee92389d38c3d120445864d1085c421ee91c7ed05d66fb9bb76050"
+dependencies = [
+ "blocking",
+ "c2rust-bitfields",
+ "futures",
+ "libloading",
+ "log",
+ "thiserror",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ socket2 = "0.5.7"
 # tokio = { path = "../tokio/tokio" }
 smoltcp = { git = 'https://github.com/smoltcp-rs/smoltcp', rev = 'ef67e7b46cabf49783053cbf68d8671ed97ff8d4' }
 boringtun = { git = 'https://github.com/cloudflare/boringtun', rev = 'e3252d9c4f4c8fc628995330f45369effd4660a1' }
+# tun2 = { path = "../rust-tun" }
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.57.0"
@@ -81,6 +82,9 @@ core-foundation = "0.10"
 cocoa = "0.26"
 objc = "0.2"
 sysinfo = "0.29.10"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tun2 = { version = "3.1.8", features = ["async"] }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/mitmproxy-rs/mitmproxy_rs/__init__.pyi
+++ b/mitmproxy-rs/mitmproxy_rs/__init__.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 from typing import final, overload, TypeVar
-from . import certs, dns, local, process_info, udp, wireguard
+from . import certs, dns, local, process_info, tun, udp, wireguard
 
 T = TypeVar("T")
 
@@ -60,6 +60,7 @@ __all__ = [
     "dns",
     "local",
     "process_info",
+    "tun",
     "udp",
     "wireguard",
     "Stream",

--- a/mitmproxy-rs/mitmproxy_rs/tun.pyi
+++ b/mitmproxy-rs/mitmproxy_rs/tun.pyi
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import final
+from . import Stream
+
+async def create_tun_interface(
+        handle_tcp_stream: Callable[[Stream], Awaitable[None]],
+        handle_udp_stream: Callable[[Stream], Awaitable[None]],
+        tun_name: str | None = None,
+) -> TunInterface: ...
+@final
+class TunInterface:
+    def tun_name(self) -> str: ...
+    def close(self) -> None: ...
+    async def wait_closed(self) -> None: ...
+    def __repr__(self) -> str: ...

--- a/mitmproxy-rs/pytests/test_task.rs
+++ b/mitmproxy-rs/pytests/test_task.rs
@@ -82,7 +82,7 @@ mod tests {
                 connection_id: ConnectionId::unassigned_udp(),
                 src_addr: "127.0.0.1:51232".parse()?,
                 dst_addr: "127.0.0.1:53".parse()?,
-                tunnel_info: TunnelInfo::Udp,
+                tunnel_info: TunnelInfo::None,
                 command_tx: None,
             })
             .await

--- a/mitmproxy-rs/src/lib.rs
+++ b/mitmproxy-rs/src/lib.rs
@@ -60,6 +60,12 @@ mod mitmproxy_rs {
     }
 
     #[pymodule]
+    mod tun {
+        #[pymodule_export]
+        use crate::server::{create_tun_interface, TunInterface};
+    }
+
+    #[pymodule]
     mod udp {
         #[pymodule_export]
         use crate::server::{start_udp_server, UdpServer};

--- a/mitmproxy-rs/src/process_info.rs
+++ b/mitmproxy-rs/src/process_info.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 #[cfg(any(windows, target_os = "macos"))]
 use mitmproxy::processes;
 
-#[pyclass(module = "mitmproxy_rs", frozen)]
+#[pyclass(module = "mitmproxy_rs.process_info", frozen)]
 pub struct Process(mitmproxy::processes::ProcessInfo);
 
 #[pymethods]

--- a/mitmproxy-rs/src/server/local_redirector.rs
+++ b/mitmproxy-rs/src/server/local_redirector.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use crate::server::base::Server;
 use tokio::sync::mpsc;
 
-#[pyclass(module = "mitmproxy_rs")]
+#[pyclass(module = "mitmproxy_rs.local")]
 #[derive(Debug)]
 pub struct LocalRedirector {
     server: Server,

--- a/mitmproxy-rs/src/server/mod.rs
+++ b/mitmproxy-rs/src/server/mod.rs
@@ -1,8 +1,10 @@
 mod base;
 mod local_redirector;
+mod tun;
 mod udp;
 mod wireguard;
 
 pub use local_redirector::{start_local_redirector, LocalRedirector};
+pub use tun::{create_tun_interface, TunInterface};
 pub use udp::{start_udp_server, UdpServer};
 pub use wireguard::{start_wireguard_server, WireGuardServer};

--- a/mitmproxy-rs/src/server/tun.rs
+++ b/mitmproxy-rs/src/server/tun.rs
@@ -1,0 +1,63 @@
+use crate::server::base::Server;
+use pyo3::prelude::*;
+
+/// An open TUN interface.
+///
+/// A new tun interface can be created by calling `create_tun_interface`.
+#[pyclass(module = "mitmproxy_rs.tun")]
+#[derive(Debug)]
+pub struct TunInterface {
+    tun_name: String,
+    server: Server,
+}
+
+#[pymethods]
+impl TunInterface {
+    /// Get the tunnel interface name.
+    pub fn tun_name(&self) -> &str {
+        &self.tun_name
+    }
+
+    /// Request the interface to be closed.
+    pub fn close(&mut self) {
+        self.server.close()
+    }
+
+    /// Wait until the interface has shut down.
+    pub fn wait_closed<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
+        self.server.wait_closed(py)
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("TunInterface({})", self.tun_name)
+    }
+}
+
+/// Create a TUN interface that is configured with the given parameters:
+///
+/// - `handle_tcp_stream`: An async function that will be called for each new TCP `Stream`.
+/// - `handle_udp_stream`: An async function that will be called for each new UDP `Stream`.
+/// - `tun_name`: An optional string to specify the tunnel name. By default, tun0, ... will be used.
+///
+/// *Availability: Linux*
+#[pyfunction]
+pub fn create_tun_interface(
+    py: Python<'_>,
+    handle_tcp_stream: PyObject,
+    handle_udp_stream: PyObject,
+    tun_name: Option<String>,
+) -> PyResult<Bound<PyAny>> {
+    #[cfg(target_os = "linux")]
+    {
+        let conf = mitmproxy::packet_sources::tun::TunConf { tun_name };
+        pyo3_asyncio_0_21::tokio::future_into_py(py, async move {
+            let (server, tun_name) =
+                Server::init(conf, handle_tcp_stream, handle_udp_stream).await?;
+            Ok(TunInterface { server, tun_name })
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    Err(pyo3::exceptions::PyNotImplementedError::new_err(
+        "TUN proxy mode is only available on Linux",
+    ))
+}

--- a/mitmproxy-rs/src/server/udp.rs
+++ b/mitmproxy-rs/src/server/udp.rs
@@ -14,7 +14,7 @@ use crate::util::socketaddr_to_py;
 /// The public API is intended to be similar to the API provided by
 /// [`asyncio.Server`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.Server)
 /// from the Python standard library.
-#[pyclass(module = "mitmproxy_rs")]
+#[pyclass(module = "mitmproxy_rs.udp")]
 #[derive(Debug)]
 pub struct UdpServer {
     /// local address of the UDP socket

--- a/mitmproxy-rs/src/server/wireguard.rs
+++ b/mitmproxy-rs/src/server/wireguard.rs
@@ -16,7 +16,7 @@ use crate::server::base::Server;
 /// The public API is intended to be similar to the API provided by
 /// [`asyncio.Server`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.Server)
 /// from the Python standard library.
-#[pyclass(module = "mitmproxy_rs")]
+#[pyclass(module = "mitmproxy_rs.wireguard")]
 #[derive(Debug)]
 pub struct WireGuardServer {
     /// local address of the WireGuard UDP socket

--- a/mitmproxy-rs/src/stream.rs
+++ b/mitmproxy-rs/src/stream.rs
@@ -194,7 +194,7 @@ impl Stream {
                 }
                 _ => (),
             },
-            TunnelInfo::Udp {} => (),
+            TunnelInfo::None {} => (),
         }
         match default {
             Some(x) => Ok(x),

--- a/mitmproxy-rs/src/udp_client.rs
+++ b/mitmproxy-rs/src/udp_client.rs
@@ -50,7 +50,7 @@ pub fn open_udp_connection(
             command_tx,
             peername,
             sockname,
-            tunnel_info: TunnelInfo::Udp,
+            tunnel_info: TunnelInfo::None,
         };
 
         Ok(stream)

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -19,7 +19,7 @@ pub enum TunnelInfo {
         /// an unresolved remote_endpoint instead.
         remote_endpoint: Option<(String, u16)>,
     },
-    Udp,
+    None,
 }
 
 /// Events that are sent by WireGuard to the TCP stack.

--- a/src/packet_sources/mod.rs
+++ b/src/packet_sources/mod.rs
@@ -6,6 +6,8 @@ use crate::messages::{TransportCommand, TransportEvent};
 
 #[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(target_os = "linux")]
+pub mod tun;
 pub mod udp;
 #[cfg(windows)]
 pub mod windows;

--- a/src/packet_sources/tun.rs
+++ b/src/packet_sources/tun.rs
@@ -1,0 +1,113 @@
+use anyhow::{Context, Result};
+
+use crate::messages::{
+    NetworkCommand, NetworkEvent, SmolPacket, TransportCommand, TransportEvent, TunnelInfo,
+};
+use crate::network::{add_network_layer, MAX_PACKET_SIZE};
+use crate::packet_sources::{PacketSourceConf, PacketSourceTask};
+use tokio::sync::mpsc::{Permit, Receiver, UnboundedReceiver};
+use tokio::sync::{broadcast, mpsc::Sender};
+use tun2::AbstractDevice;
+
+pub struct TunConf {
+    pub tun_name: Option<String>,
+}
+
+impl PacketSourceConf for TunConf {
+    type Task = TunTask;
+    type Data = String;
+
+    fn name(&self) -> &'static str {
+        "TUN interface"
+    }
+
+    async fn build(
+        self,
+        transport_events_tx: Sender<TransportEvent>,
+        transport_commands_rx: UnboundedReceiver<TransportCommand>,
+        shutdown: broadcast::Receiver<()>,
+    ) -> Result<(Self::Task, Self::Data)> {
+        let mut config = tun2::Configuration::default();
+        config.mtu(MAX_PACKET_SIZE as u16);
+        config.up();
+        if let Some(tun_name) = self.tun_name {
+            config.tun_name(&tun_name);
+        }
+
+        let device = tun2::create_as_async(&config).context("Failed to create TUN device")?;
+        let tun_name = device.tun_name().context("Failed to get TUN name")?;
+
+        let (network_task_handle, net_tx, net_rx) =
+            add_network_layer(transport_events_tx, transport_commands_rx, shutdown)?;
+
+        Ok((
+            TunTask {
+                device,
+                net_tx,
+                net_rx,
+                network_task_handle,
+            },
+            tun_name,
+        ))
+    }
+}
+
+pub struct TunTask {
+    device: tun2::AsyncDevice,
+
+    net_tx: Sender<NetworkEvent>,
+    net_rx: Receiver<NetworkCommand>,
+    network_task_handle: tokio::task::JoinHandle<Result<()>>,
+}
+
+impl PacketSourceTask for TunTask {
+    async fn run(mut self) -> Result<()> {
+        let size = self.device.mtu()? as usize + tun2::PACKET_INFORMATION_LENGTH;
+        let mut buf = vec![0; size];
+
+        let mut packet_to_send = Vec::new();
+        let mut permit: Option<Permit<NetworkEvent>> = None;
+
+        // Required on macOS, but currently crashes on Linux with tokio.
+        //let (mut writer, mut reader) = self.device.split().context("failed to split device")?;
+
+        loop {
+            tokio::select! {
+                // Monitor the network task for errors or planned shutdown.
+                // This way we implicitly monitor the shutdown broadcast channel.
+                exit = &mut self.network_task_handle => break exit.context("network task panic")?.context("network task error")?,
+                // wait for transport_events_tx channel capacity...
+                Ok(p) = self.net_tx.reserve(), if permit.is_none() => {
+                    permit = Some(p);
+                },
+                // ... or process incoming packets
+                r = self.device.recv(buf.as_mut_slice()), if permit.is_some() => {
+                    let len = r.context("TUN read() failed")?;
+
+                    let Ok(packet) = SmolPacket::try_from(buf[..len].to_vec()) else {
+                        log::error!("Skipping invalid packet from tun interface: {:?}", &buf[..len]);
+                        continue;
+                    };
+                    permit.take().unwrap().send(NetworkEvent::ReceivePacket {
+                        packet,
+                        tunnel_info: TunnelInfo::None,
+                    });
+                },
+                // send_to is cancel safe, so we can use that for backpressure.
+                r = self.device.send(&packet_to_send), if !packet_to_send.is_empty() => {
+                    r.context("TUN write() failed")?;
+                    packet_to_send.clear();
+                },
+                Some(command) = self.net_rx.recv(), if packet_to_send.is_empty() => {
+                    match command {
+                        NetworkCommand::SendPacket(packet) => {
+                            packet_to_send = packet.into_inner();
+                        }
+                    }
+                }
+            }
+        }
+        log::debug!("TUN interface task shutting down.");
+        Ok(())
+    }
+}

--- a/src/packet_sources/udp.rs
+++ b/src/packet_sources/udp.rs
@@ -131,7 +131,7 @@ impl PacketSourceTask for UdpTask {
                             dst_addr: self.local_addr,
                             payload: udp_buf[..len].to_vec(),
                         },
-                        TunnelInfo::Udp {},
+                        TunnelInfo::None {},
                         permit.take().unwrap()
                     );
                 },


### PR DESCRIPTION
This PR adds `mitmproxy_rs.tun` for tun mode on Linux. No tests on the Rust side as it's mostly plumbing and we can't open tun interface without root, so this will be something for an end-to-end test in mitmproxy.

Example Usage:
```shell
mitmdump --mode tun
curl --interface tun0 https://example.com
```