### PR TITLE
Processing of TCP packets sent by the SYSTEM process using windows-redirector.exe

### DIFF
--- a/mitmproxy-windows/redirector/src/main2.rs
+++ b/mitmproxy-windows/redirector/src/main2.rs
@@ -264,11 +264,6 @@ async fn main() -> Result<()> {
 
                     continue;
                 };
-                let connection_id = ConnectionId {
-                    proto,
-                    src: SocketAddr::from((address.local_address(), address.local_port())),
-                    dst: SocketAddr::from((address.remote_address(), address.remote_port())),
-                };
 
                 if connection_id.src.ip().is_multicast() || connection_id.dst.ip().is_multicast() {
 

--- a/mitmproxy-windows/redirector/src/main2.rs
+++ b/mitmproxy-windows/redirector/src/main2.rs
@@ -234,7 +234,7 @@ async fn main() -> Result<()> {
                     debug!("Skipping PID 4");
 
                     clear_connections(
-                        connection_id,
+                        packet.connection_id(),
                         &mut connections,
                         &inject_handle,
                         &mut ipc_tx,
@@ -248,7 +248,7 @@ async fn main() -> Result<()> {
                     warn!("Unknown transport protocol: {}", address.protocol());
 
                     clear_connections(
-                        connection_id,
+                        packet.connection_id(),
                         &mut connections,
                         &inject_handle,
                         &mut ipc_tx,
@@ -266,7 +266,7 @@ async fn main() -> Result<()> {
                 if connection_id.src.ip().is_multicast() || connection_id.dst.ip().is_multicast() {
 
                     clear_connections(
-                        connection_id,
+                        packet.connection_id(),
                         &mut connections,
                         &inject_handle,
                         &mut ipc_tx,


### PR DESCRIPTION
When accessing the NAS through Windows Explorer, the TCP handshake packets from the System process (PID=4) are held at the if block on line 188 of the main2.rs. However, when a socket event occurs, processing is skipped at the if block on line 232 of the main2.rs, preventing Windows Explorer from establishing a TCP connection.

Wouldn't it be better to reinject the connections held in connections back into the network before skipping them, even if the process is the System process?