### PR TITLE
WireGuard keylog file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/cloudflare/boringtun?rev=e3252d9c4f4c8fc628995330f45369effd4660a1#e3252d9c4f4c8fc628995330f45369effd4660a1"
+source = "git+https://github.com/ntqbit/boringtun?branch=feature/key_logger#0437b44b3d34bf74cd364f51f62c8ac3f4b6962d"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ socket2 = "0.5.8"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }
-boringtun = { git = 'https://github.com/cloudflare/boringtun', rev = 'e3252d9c4f4c8fc628995330f45369effd4660a1' }
+boringtun = { git = "https://github.com/ntqbit/boringtun", branch = "feature/key_logger"}
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.58.0"

--- a/mitmproxy-rs/src/server/wireguard.rs
+++ b/mitmproxy-rs/src/server/wireguard.rs
@@ -6,7 +6,7 @@ use mitmproxy::packet_sources::wireguard::WireGuardConf;
 
 use pyo3::prelude::*;
 
-use boringtun::x25519::PublicKey;
+use boringtun::{noise::keys_logger::KeyLogger, x25519::PublicKey};
 
 use crate::server::base::Server;
 
@@ -60,7 +60,9 @@ impl WireGuardServer {
 /// - `peer_public_keys`: List of public X25519 keys for WireGuard peers as base64-encoded strings.
 /// - `handle_tcp_stream`: An async function that will be called for each new TCP `Stream`.
 /// - `handle_udp_stream`: An async function that will be called for each new UDP `Stream`.
+/// - `key_logger`: An optional function that will be called for each key when handshake is completed.
 #[pyfunction]
+#[pyo3(signature = (host, port, private_key, peer_public_keys, handle_tcp_stream, handle_udp_stream, key_logger=None))]
 pub fn start_wireguard_server(
     py: Python<'_>,
     host: String,
@@ -69,20 +71,37 @@ pub fn start_wireguard_server(
     peer_public_keys: Vec<String>,
     handle_tcp_stream: PyObject,
     handle_udp_stream: PyObject,
+    key_logger: Option<PyObject>,
 ) -> PyResult<Bound<PyAny>> {
     let private_key = string_to_key(private_key)?;
     let peer_public_keys = peer_public_keys
         .into_iter()
         .map(string_to_key)
         .collect::<PyResult<Vec<PublicKey>>>()?;
+
+    let key_logger = key_logger
+        .map(|key_logger| Box::new(PythonKeyLogger(key_logger)) as Box<dyn KeyLogger + Sync>);
+
     let conf = WireGuardConf {
         host,
         port,
         private_key,
         peer_public_keys,
+        key_logger,
     };
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let (server, local_addr) = Server::init(conf, handle_tcp_stream, handle_udp_stream).await?;
         Ok(WireGuardServer { server, local_addr })
     })
+}
+
+struct PythonKeyLogger(PyObject);
+
+impl KeyLogger for PythonKeyLogger {
+    fn log_key(&self, name: &str, keymaterial: &str) {
+        Python::with_gil(|py| {
+            // The error is intentionally ignored.
+            let _ = self.0.call1(py, (name, keymaterial));
+        });
+    }
 }


### PR DESCRIPTION
Implements https://github.com/mitmproxy/mitmproxy/issues/7418.

I had to fork the upstream WireGuard library `boringtun` since the upstream version does not allow to extract handshake keys. The fork is here: https://github.com/ntqbit/boringtun/tree/feature/key_logger

The changes made are non-breaking, neither in fork of `boringtun` nor in `mitmproxy_rs`.