### PR TITLE
Remove scope_id when parsing IPv6 addresses

### DIFF
--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -63,10 +63,6 @@ mod tests {
             port: 8080,
         };
         assert!(SocketAddr::try_from(&c).is_ok());
-        assert_eq!(
-            SocketAddr::try_from(&a),
-            SocketAddr::try_from(&c)
-        );
+        assert_eq!(SocketAddr::try_from(&a), SocketAddr::try_from(&c));
     }
-
 }


### PR DESCRIPTION
fix https://github.com/mitmproxy/mitmproxy/issues/7547