### PR TITLE
Always reclaim buffer space

### DIFF
--- a/mitmproxy-linux/README.md
+++ b/mitmproxy-linux/README.md
@@ -16,7 +16,8 @@ This package requires the following software to build (via https://aya-rs.dev/bo
 
 1. Install build dependencies (see above).
 2. Install mitmproxy_linux as editable: `pip install -e .`
-3. Run something along the lines of `mitmdump --mode local:curl`.  
+3. Remove `$VIRTUAL_ENV/bin/mitmproxy-linux-redirector`
+4. Run something along the lines of `mitmdump --mode local:curl`.  
    You should see a `Development mode: Compiling mitmproxy-linux-redirector...` message.
 
 

--- a/src/packet_sources/macos.rs
+++ b/src/packet_sources/macos.rs
@@ -152,11 +152,8 @@ impl PacketSourceTask for MacOsTask {
                 },
                 // pipe through changes to the intercept list
                 Some(conf) = self.conf_rx.recv() => {
-                    let msg = ipc::InterceptConf::from(conf);
-                    let len = msg.encoded_len();
-                    let mut buf = BytesMut::with_capacity(len);
-                    msg.encode(&mut buf)?;
-                    control_channel.send(buf.freeze()).await.context("Failed to write to control channel")?;
+                    let msg = ipc::InterceptConf::from(conf).encode_to_vec();
+                    control_channel.send(msg).await.context("Failed to write to control channel")?;
                 },
             }
         }
@@ -191,12 +188,12 @@ impl ConnectionTask {
                 .read_u32()
                 .await
                 .context("Failed to read handshake.")? as usize;
-            let mut buf = BytesMut::zeroed(len);
+            let mut buf = vec![0; len];
             self.stream
                 .read_exact(&mut buf)
                 .await
                 .context("Failed to read handshake contents.")?;
-            NewFlow::decode(&buf[..]).context("Invalid handshake IPC")?
+            NewFlow::decode(buf.as_slice()).context("Invalid handshake IPC")?
         };
 
         match new_flow {


### PR DESCRIPTION
This fixes https://github.com/mitmproxy/mitmproxy/issues/7548.

It turns out BytesMut has a really annoying failure mode where capacity needs to be explicitly reclaimed, otherwise things break after a while.