### PR TITLE
Bump minimum python version

### DIFF
--- a/mitmproxy-linux/pyproject.toml
+++ b/mitmproxy-linux/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mitmproxy_linux"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/mitmproxy-macos/pyproject.toml
+++ b/mitmproxy-macos/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "mitmproxy-macos"
 dynamic = ["version"]
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 
 [project.urls]

--- a/mitmproxy-rs/Cargo.toml
+++ b/mitmproxy-rs/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { version = "1.0.93", features = ["backtrace"] }
 data-encoding = "2.7.0"
 log = "0.4.25"
 once_cell = "1"
-pyo3 = { version = "0.23", features = ["abi3", "abi3-py310", "anyhow"] }
+pyo3 = { version = "0.23", features = ["abi3", "abi3-py312", "anyhow"] }
 pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime", "testing", "attributes"] }
 pyo3-log = "0.12.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }

--- a/mitmproxy-rs/pyproject.toml
+++ b/mitmproxy-rs/pyproject.toml
@@ -5,14 +5,12 @@ build-backend = "maturin"
 [project]
 name = "mitmproxy_rs"
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 5 - Production/Stable",

--- a/mitmproxy-windows/pyproject.toml
+++ b/mitmproxy-windows/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "mitmproxy-windows"
 dynamic = ["version"]
 license = "LGPL-3.0-or-later"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 
 [project.urls]


### PR DESCRIPTION
mitmproxy itself requires 3.12+, so no need for us here to stay on 3.10.