### PR TITLE
add venv to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ virtualenv activated and then run the following:
 ```shell
 git clone https://github.com/mitmproxy/mitmproxy_rs.git
 cd mitmproxy_rs/mitmproxy-rs
+
+python3 -m venv venv
+source venv/bin/activate
+
 maturin develop
 ```
 


### PR DESCRIPTION
# Description of the problem

Trying to set up this code for development for the first time, I followed the instructions without thinking too much, and it didn't work. I got this message when running `maturin develop`:

`
💥 maturin failed
  Caused by: Couldn't find a virtualenv or conda environment, but you need one to use this command. For maturin to find your virtualenv you need to either set VIRTUAL_ENV (through activate), set CONDA_PREFIX (through conda activate) or have a virtualenv called .venv in the current or any parent folder. See https://virtualenv.pypa.io/en/latest/index.html on how to use virtualenv or use `maturin build` and `pip install <path/to/wheel>` instead.
`

# Solution

What was missing were the commands related to setting up the virtual environment.
