### PR TITLE
FEATURE: Allow to use regex in process name

### DIFF
--- a/mitmproxy-macos/redirector/network-extension/InterceptConf.swift
+++ b/mitmproxy-macos/redirector/network-extension/InterceptConf.swift
@@ -31,9 +31,14 @@ enum Pattern {
             return processInfo.pid == pid
         case .process(let name):
             if let processName = processInfo.path {
-                return processName.contains(name)
+                if let regex = try? NSRegularExpression(pattern: name) {
+                    let range = NSRange(location: 0, length: processName.utf16.count)
+                    return regex.firstMatch(in: processName, range: range) != nil
+                } else {
+                    return processName.contains(name)
+                }
             } else {
-                return false 
+                return false
             }
         }
     }


### PR DESCRIPTION
It is not enough to use "contains" in my case, that's why I've added it:
I want to proxy apps on iOS simulators during ui tests runs. Simulators run in parallel, each simulator has separate proxy to collect separate logs, and app is reinstalled during run for each test, that's why path is changed for each test. I use it this way "mitmdump --mode local:"<SIMULATOR_UDID>.*MyAppName""