### PR TITLE
bump boringtun to latest commit to pull FreeBSD fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/cloudflare/boringtun?rev=e3252d9c4f4c8fc628995330f45369effd4660a1#e3252d9c4f4c8fc628995330f45369effd4660a1"
+source = "git+https://github.com/cloudflare/boringtun?rev=2f3c85f5c4a601018c10b464b1ca890d9504bf6e#2f3c85f5c4a601018c10b464b1ca890d9504bf6e"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ socket2 = "0.5.10"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }
-boringtun = { git = 'https://github.com/cloudflare/boringtun', rev = 'e3252d9c4f4c8fc628995330f45369effd4660a1' }
+boringtun = { git = 'https://github.com/cloudflare/boringtun', rev = '2f3c85f5c4a601018c10b464b1ca890d9504bf6e' }
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.61.1"

--- a/src/packet_sources/wireguard.rs
+++ b/src/packet_sources/wireguard.rs
@@ -71,8 +71,7 @@ impl PacketSourceConf for WireGuardConf {
                 Some(25),
                 index,
                 None,
-            )
-            .map_err(|error| anyhow!(error))?;
+            );
 
             let peer = Arc::new(Mutex::new(WireGuardPeer {
                 tunnel,

--- a/wireguard-test-client/src/main.rs
+++ b/wireguard-test-client/src/main.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         <[u8; 32]>::try_from(BASE64.decode(b"mitmV5Wo7pRJrHNAKhZEI0nzqqeO8u4fXG+zUbZEXA0=")?)
             .unwrap(),
     );
-    let mut tunn = Tunn::new(static_private, peer_static_public, None, None, 0, None).unwrap();
+    let mut tunn = Tunn::new(static_private, peer_static_public, None, None, 0, None);
 
     let socket = UdpSocket::bind("127.0.0.1:0")?;
     socket.set_read_timeout(Some(Duration::from_secs(1)))?;


### PR DESCRIPTION
This pulls in fixes for https://github.com/cloudflare/boringtun/issues/420, which allows FreeBSD to package mitmproxy_rs and eventually update mitmproxy to latest upstream.