### PR TITLE
Feature: Check for matching protobuf message without service before fallbacks

### DIFF
--- a/mitmproxy-contentviews/src/protobuf/existing_proto_definitions.rs
+++ b/mitmproxy-contentviews/src/protobuf/existing_proto_definitions.rs
@@ -78,6 +78,12 @@ fn find_best_message(
                     rpc.method
                 );
             }
+            for method in file.messages() {
+                if method.proto().name() != rpc.method {
+                    continue;
+                }
+                return Some(method);
+            }
         }
         log::info!("Did not find {rpc} in protobuf definitions.");
     }
@@ -144,7 +150,10 @@ impl std::fmt::Display for RpcInfo {
         if !self.package.is_empty() {
             write!(f, "{}.", self.package)?;
         }
-        write!(f, "{}.{}", self.service, self.method)
+        if !self.service.is_empty() {
+            write!(f, "{}.", self.service)?;
+        }
+        write!(f, "{}", self.method)
     }
 }
 


### PR DESCRIPTION
This PR makes it so that the `find_best_message` function for protobuf message detection will check any messages in the .proto files that don't have services, before falling back to either the first service or first message found.

I've also made it so that `fmt` display function for `RpcInfo` will check if the service is empty or not. Just helps to make logging a bit prettier for people who make their own contentview scripts and don't fill in a service when changing the URL path.