### PR TITLE
Unbreak CI, bump MSRV to 1.86

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,5 +27,5 @@ runs:
       with:
         key: ${{ inputs.rust-version }} # proxy value for glibc version
     - if: runner.os == 'Linux'
-      run: cargo install --locked bpf-linker
+      run: cargo install --locked bpf-linker@0.9.15
       shell: bash

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: mhils/workflows/checkout@5b6540d578f48644ffa5e955cedadc81034cb7d8  # v18.0
-      - run: brew install swift-protobuf
+      # FIXME: https://github.com/mitmproxy/mitmproxy/issues/7877 - bump SwiftProtobuf and then re-add this here.
+      # - run: brew install swift-protobuf
       - run: cargo install protoc-gen-prost
       - run: protoc --proto_path=./src/ipc/ mitmproxy_ipc.proto
           --prost_out=./src/ipc/

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MSRV: "1.85"  # Minimum Supported Rust Version
+  MSRV: "1.86"  # Minimum Supported Rust Version
 
 jobs:
   protobuf:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            rust: "1.85"  # MSRV - can't use variables here.
+            rust: "1.86"  # MSRV - can't use variables here.
             args: --exclude mitmproxy-linux-ebpf
           - os: macos-latest
-            rust: "1.85"  # MSRV - can't use variables here.
+            rust: "1.86"  # MSRV - can't use variables here.
             args: --exclude mitmproxy-linux-ebpf
           - os: ubuntu-22.04
-            rust: "1.85"  # MSRV - can't use variables here.
+            rust: "1.86"  # MSRV - can't use variables here.
             args: --exclude mitmproxy-linux-ebpf
           - os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.13.0-dev"
 publish = false
 repository = "https://github.com/mitmproxy/mitmproxy-rs"
 edition = "2021"
-rust-version = "1.85"  # MSRV
+rust-version = "1.86"  # MSRV
 
 [workspace.dependencies]
 aya = { version = "0.13.0", default-features = false }


### PR DESCRIPTION
This is required by the latest bpf-linker release, which we now also pin to avoid CI breakage in the future.